### PR TITLE
Fix response schema

### DIFF
--- a/schemas/reconciliation-response.json
+++ b/schemas/reconciliation-response.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema#",
     "$id": "https://reconciliation-api.github.io/specs/schemas/reconciliation-response.json",
-    "type": "array",
+    "type": "object",
     "description": "This schema validates lists of reconciliation candidates",
     "items": {
         "type": "object",

--- a/schemas/reconciliation-response.json
+++ b/schemas/reconciliation-response.json
@@ -18,6 +18,10 @@
                 "type": "number",
                 "description": "Number indicating how likely it is that the candidate matches the query"
             },
+            "match": {
+              "type": "boolean",
+              "description": "Boolean value indicating whether the candiate is a certain match or not."
+            },
             "type": {
                 "type": "array",
                 "description": "Types the candidate entity belongs to",


### PR DESCRIPTION
The response schema would not validate responses from the lobid-gnd endpoint ([example](https://lobid.org/gnd/reconcile/?queries=%7B%22q1%22%3A%7B%22query%22%3A%22Twain%2C+Mark%22%7D%7D)). This PR changes the root type of the response schema to `object`. It also adds the optional `match` property to the schema.

BTW, looking at the [current documentation]/(https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-API#query-response), we should make all properties `required`, i.e. also add `type` and `match`.