### PR TITLE
Note that 'properties' is similar to WHERE in SQL

### DIFF
--- a/0.1/index.html
+++ b/0.1/index.html
@@ -40,7 +40,11 @@
             orcid: "0000-0001-8829-1989",
             company: "hbz, Cologne",
             companyURL: "https://www.hbz-nrw.de/"
-          }
+          },
+	  {
+	    name: "Thad Guidry Sr.",
+	    url: "https://www.linkedin.com/in/thadguidry/"
+	  }
         ],
         localBiblio: {
           "beek-2018": {"aliasOf": "doi:10.1007/978-3-319-93417-4_5"},
@@ -358,7 +362,8 @@ database are instances of this type.<dd>
 	    <dt><code>limit</code></dt>
             <dd>Optionally, a limit on the number of candidates to return, which must be a positive integer;</dd>
 	    <dt><code>properties</code></dt>
-	    <dd>Optionally, a map from <a href='#properties'>property</a> identifiers to a list of <a>property values</a> (or list of <a>property values</a>). Those are used to refine the set of candidates, by allowing clients to specify other attributes of entities, beyond their name in the <code>query</code> field;</dd>
+	    <dd>Optionally, a map from <a href='#properties'>property</a> identifiers to a list of <a>property values</a> (or list of <a>property values</a>). These are used to further filter the set of candidates (similar to a WHERE clause in SQL, by allowing clients to specify other attributes of entities that should match, beyond their name in the <code>query</code> field.
+		How reconciliation services handle this further restriction ("must match all properties" or "should match some") and how it affects the score, is up to the service;</dd>
 	    <dt><code>type_strict</code></dt>
             <dd>Optionally, a type strictness parameter, which can be one of the strings <code>"should"</code>, <code>"all"</code> or <code>"any"</code>.</dd>
           </dl>

--- a/latest/index.html
+++ b/latest/index.html
@@ -368,7 +368,7 @@ database are instances of this type.<dd>
 	    <dt><code>properties</code></dt>
 	    <dd>Optionally, a map from <a href='#properties'>property</a> identifiers to a list of <a>property values</a> (or list of <a>property values</a>). These are used to further filter the set of candidates (similar to a WHERE clause in SQL),
 		by allowing clients to specify other attributes of entities that should match, beyond their name in the <code>query</code> field.
-		How reconciliation services handle this further restriction ("must match all properties" or "should match some") and how it affects the score, is up to the service.;</dd>
+		How reconciliation services handle this further restriction ("must match all properties" or "should match some") and how it affects the score, is up to the service;</dd>
 	    <dt><code>type_strict</code></dt>
             <dd>Optionally, a type strictness parameter, which can be one of the strings <code>"should"</code>, <code>"all"</code> or <code>"any"</code>.</dd>
           </dl>

--- a/latest/index.html
+++ b/latest/index.html
@@ -42,6 +42,10 @@
             company: "hbz, Cologne",
             companyURL: "https://www.hbz-nrw.de/"
           },
+          {
+            name: "Thad Guidry Sr.",
+            url: "https://www.linkedin.com/in/thadguidry/"
+          },
           // add yourself here!
           {
             name: "Add Yourself Here!"
@@ -362,7 +366,9 @@ database are instances of this type.<dd>
 	    <dt><code>limit</code></dt>
             <dd>Optionally, a limit on the number of candidates to return, which must be a positive integer;</dd>
 	    <dt><code>properties</code></dt>
-	    <dd>Optionally, a map from <a href='#properties'>property</a> identifiers to a list of <a>property values</a> (or list of <a>property values</a>). Those are used to refine the set of candidates, by allowing clients to specify other attributes of entities, beyond their name in the <code>query</code> field;</dd>
+	    <dd>Optionally, a map from <a href='#properties'>property</a> identifiers to a list of <a>property values</a> (or list of <a>property values</a>). These are used to further filter the set of candidates (similar to a WHERE clause in SQL),
+		by allowing clients to specify other attributes of entities that should match, beyond their name in the <code>query</code> field.
+		How reconciliation services handle this further restriction ("must match all properties" or "should match some") and how it affects the score, is up to the service.;</dd>
 	    <dt><code>type_strict</code></dt>
             <dd>Optionally, a type strictness parameter, which can be one of the strings <code>"should"</code>, <code>"all"</code> or <code>"any"</code>.</dd>
           </dl>


### PR DESCRIPTION
I think this is useful to note to implementers.  This also exposes a need to possibly add a new parameter for 'properties_strict' (like type_strict) where the value might be "must" or "should" and would offer a slightly different score?

I'm not sure if I wrote this up in entirely the best way, but I wanted to make it easier to understand since many folks know how database querying works.  Just the original word "refine" I think is not enough here.  Also, we should note places in the specs where clients can specify "conditions" for filtering and how scoring might be controlled or affected further, but unsure how best to present that in ReSpec.
Maybe it could be presented with some colored metadata element or INFO element like [CONDITIONAL LOGICAL THAT AFFECTS SCORING] or similar.