### PR TITLE
Announce which API versions are supported in manifest

### DIFF
--- a/latest/examples/manifest/invalid/missing-version.json
+++ b/latest/examples/manifest/invalid/missing-version.json
@@ -1,5 +1,4 @@
 {
-    "versions": ["0.2"],
     "name": "VIAF",
     "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
     "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD"

--- a/latest/examples/manifest/invalid/old-version.json
+++ b/latest/examples/manifest/invalid/old-version.json
@@ -1,0 +1,6 @@
+{
+    "versions": ["0.1"],
+    "name": "VIAF",
+    "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
+    "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD"
+}

--- a/latest/examples/manifest/valid/codefork-viaf.json
+++ b/latest/examples/manifest/valid/codefork-viaf.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "VIAF",
   "identifierSpace": "http://rdf.freebase.com/ns/user/hangy/viaf",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",

--- a/latest/examples/manifest/valid/findthatcharity.json
+++ b/latest/examples/manifest/valid/findthatcharity.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "findthatcharity",
   "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",

--- a/latest/examples/manifest/valid/fundref.json
+++ b/latest/examples/manifest/valid/fundref.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "Open Funder Registry Reconciliation Service",
   "identifierSpace": "http://openfunder.crossref.org/openfunder",
   "schemaSpace": "http://openfunder.crossref.org/ns/type.object.id",

--- a/latest/examples/manifest/valid/geocollider-sinatra.json
+++ b/latest/examples/manifest/valid/geocollider-sinatra.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "Pleiades Reconciliation for OpenRefine",
   "schemaSpace": "https://pleiades.stoa.org/places/",
   "identifierSpace": "https://pleiades.stoa.org/places/vocab#",

--- a/latest/examples/manifest/valid/getty.json
+++ b/latest/examples/manifest/valid/getty.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "defaultTypes": [
     {
       "id": "/ulan",

--- a/latest/examples/manifest/valid/kerameikos.json
+++ b/latest/examples/manifest/valid/kerameikos.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "Kerameikos.org",
   "view": {
     "url": "http://kerameikos.org/id/{{id}}"

--- a/latest/examples/manifest/valid/kew.json
+++ b/latest/examples/manifest/valid/kew.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "IPNI Name Reconciliation Service",
   "identifierSpace": "http://ipni.org/urn:lsid:ipni.org:names:",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",

--- a/latest/examples/manifest/valid/lobid-gnd.json
+++ b/latest/examples/manifest/valid/lobid-gnd.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "GND reconciliation for OpenRefine",
   "identifierSpace": "https://lobid.org/gnd/",
   "schemaSpace": "https://d-nb.info/standards/elementset/gnd#AuthorityResource",

--- a/latest/examples/manifest/valid/nomisma.json
+++ b/latest/examples/manifest/valid/nomisma.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "Nomisma.org",
   "view": {
     "url": "http://nomisma.org/id/{{id}}"

--- a/latest/examples/manifest/valid/occrp.json
+++ b/latest/examples/manifest/valid/occrp.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "OCCRP Aleph",
   "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",

--- a/latest/examples/manifest/valid/ordnance-survey.json
+++ b/latest/examples/manifest/valid/ordnance-survey.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "name": "Code-Point Open Reconciliation API",
   "identifierSpace": "http://data.ordnancesurvey.co.uk/id/data/code-point-open",
   "schemaSpace": "http://data.ordnancesurvey.co.uk/id/data/code-point-open",

--- a/latest/examples/manifest/valid/vivo-cornell.json
+++ b/latest/examples/manifest/valid/vivo-cornell.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.2"],
   "view": {
     "url": "http://vivo.med.cornell.edu/individual?uri={{id}}"
   },

--- a/latest/examples/manifest/valid/wikidata.json
+++ b/latest/examples/manifest/valid/wikidata.json
@@ -1,4 +1,5 @@
 {
+  "versions": ["0.1", "0.2"],
   "name": "Wikidata (en)",
   "preview": {
     "url": "https://tools.wmflabs.org/openrefine-wikidata/en/preview?id={{id}}",

--- a/latest/index.html
+++ b/latest/index.html
@@ -273,6 +273,8 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
       <p>
         A <dfn>service manifest</dfn> consists of the following fields:
         <dl>
+          <dt><code>versions</code></dt>
+          <dd>The list of API versions supported by the endpoint, such as <code>["0.1", "0.2"]</code>. Since this field did not exist in version 0.1, services which do not declare a <code>versions</code> field are expected to only support version 0.1.</dd>
           <dt><code>name</code></dt>
           <dd>A human-readable name for the service, generally the name of the database it exposes. In the case where multiple reconciliation services exist for the same database, it is in the interest of a service to bear a meaningful name which
 will help disambiguating it from others;</dd>

--- a/latest/schemas/manifest.json
+++ b/latest/schemas/manifest.json
@@ -10,7 +10,9 @@
       "items": {
         "type": "string"
       },
-      "minItems": 1
+      "contains": {
+        "enum": ["0.2"]
+      }
     },
     "name": {
       "type": "string",

--- a/latest/schemas/manifest.json
+++ b/latest/schemas/manifest.json
@@ -4,6 +4,14 @@
   "type": "object",
   "description": "This validates a service manifest, describing the features supported by the endpoint.",
   "properties": {
+    "versions": {
+      "type": "array",
+      "description": "The list of API versions supported by this service.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
     "name": {
       "type": "string",
       "description": "A human-readable name for the service or data source"
@@ -272,6 +280,7 @@
     }
   },
   "required": [
+    "versions",
     "name",
     "identifierSpace",
     "schemaSpace"

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Test JSON examples against schemas
-for version in `echo latest`; do
+for version in "0.1" "latest"; do
 	echo "Testing version: $version"
 
 	for schema_file in `ls $version/schemas`; do


### PR DESCRIPTION
This lets services announce which version of the specs they support (possibly more than one in the same endpoint), by adding a `"versions": ["0.1","0.2"]` field to the manifest, which contains the spec versions supported by the endpoint.

 Closes #28.