### PR TITLE
Authentication mechanism

### DIFF
--- a/latest/examples/manifest/invalid/bad-authentication.json
+++ b/latest/examples/manifest/invalid/bad-authentication.json
@@ -1,0 +1,8 @@
+{
+  "name": "OpenCorporates Reconciliation Service",
+  "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
+  "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
+  "authentication": {
+     "foo": "bar"
+  }
+}

--- a/latest/examples/manifest/valid/authentication.json
+++ b/latest/examples/manifest/valid/authentication.json
@@ -1,0 +1,14 @@
+{
+  "view": {
+    "url": "http://vivo.med.cornell.edu/individual?uri={{id}}"
+  },
+  "identifierSpace": "http://vivo.med.cornell.edu/individual/",
+  "name": "VIVO Reconciliation Service",
+  "schemaSpace": "http://vivo.med.cornell.edu/individual/",
+  "authentication": {
+    "tokenName": "Client secret",
+    "required": false,
+    "documentation": "https://vivo.med.cornell.edu/reconciliation/authentication",
+    "format": "[A-Z]{4}[0-9]{7}"
+  }
+}

--- a/latest/index.html
+++ b/latest/index.html
@@ -362,7 +362,7 @@ provide when setting up the service;</dd>
            requests.
         </p>
         <p>
-           When an invalid authentication token is supplied in any HTTP request, the service MUST return an HTTP 403 error,
+           When an invalid authentication token is supplied in any HTTP request, the service MUST return an HTTP 401 error,
            even if authentication is not required.
         </p>
       </section>

--- a/latest/index.html
+++ b/latest/index.html
@@ -300,6 +300,8 @@ database are instances of this type.<dd>
           </dd>
           <dt><code>extend</code></dt>
           <dd>A <a>data extension metadata</a>, supplied if the service offers a <a href="#data-extension-service">data extension service</a>.</dd>
+          <dt><code>authentication</code></dt>
+          <dd>An <a>authentication specification</a>, supplied if the service supports <a href="#authentication">authentication</a>.</dd>
         </dl>
       </p>
       <p>For instance, a service could expose the following minimal service manifest:
@@ -333,6 +335,35 @@ database are instances of this type.<dd>
 	<p>
            In addition, endpoints exposed by the service MAY support JSONP [[JSONP]], which
            enables older web-based clients to access the service from a different domain.
+        </p>
+      </section>
+      <section>
+        <h3>Authentication</h3>
+        <p>
+           Services MAY request users to provide an authentication token when making queries.
+           They can do so by adding an <dfn>authentication specification</dfn> to their manifest. An authentication specification consists of:
+           <dl>
+             <dt><code>tokenName</code></dt>
+             <dd>A human readable name, such as <code>"API key"</code>, <code>"User token"</code> or <code>"Client secret"</code> which describes the type of authentication token in the service's own terminology. This helps users determine which token to
+provide when setting up the service;</dd>
+             <dt><code>required</code></dt>
+             <dd>A boolean value indicating whether authenticating is required to use the service;</dd>
+             <dt><code>format</code></dt>
+             <dd>An optional regular expression which describes the range of allowed values for the authentication token;</dd>
+             <dt><code>documentation</code></dt>
+             <dd>An optional URL describing the authentication mechanism used by the service: how to obtain a token from the service, the benefits of authenticating if it is not required, and any other related information.</dd>
+           </dl>
+        </p>
+        <p>
+           If a service provides an authentication specification with <code>required</code> set to <code>true</code>,
+           then clients MUST add an <code>api_key</code> GET parameter to all HTTP requests made to the service,
+           to the exception of the service manifest which can always be obtained without an authentication token. If
+           <code>required</code> is set to <code>false</code>, then clients MAY supply an <code>api_key</code> in
+           requests.
+        </p>
+        <p>
+           When an invalid authentication token is supplied in any HTTP request, the service MUST return an HTTP 403 error,
+           even if authentication is not required.
         </p>
       </section>
     </section>

--- a/latest/schemas/manifest.json
+++ b/latest/schemas/manifest.json
@@ -16,6 +16,37 @@
       "type": "string",
       "description": "A URI describing the schema used in this service"
     },
+    "authentication": {
+      "type": "object",
+      "description": "An authentication specification, provided if the service supports authentication",
+      "properties": {
+        "tokenName": {
+          "type": "string",
+          "description": "A human readable name which describes the type of authentication token in the service's own terminology",
+          "examples": [
+              "Client secret",
+              "API key",
+              "User token"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether authentication is required to use the service"
+        },
+        "format": {
+          "type": "string",
+          "description": "An optional regular expression validating the format of authentication tokens"
+        },
+        "documentation": {
+          "type": "string",
+          "description": "An optional URL pointing to a documentation page for the authentication mechanism in this service"
+        }
+      },
+      "required": [
+        "tokenName",
+        "required"
+      ]
+    },
     "view": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This is a proposal for the authentication mechanism proposed on the mailing list:
https://lists.w3.org/Archives/Public/public-reconciliation/2019Jul/0010.html

This proposes to use GET parameters, however I am not sure this is a good idea. Since we also use POST requests, this would mean submitting the `api_key` as a GET parameter to a POST request, which is not very natural (and not very easy to do with many HTTP libraries).

Authentication in GET parameters also has the downside that authentication is leaked in logs.

The motivation for GET was that it was easier to debug requests in a web browser, but browser-based testing will not be doable anyway if we move to pure JSON batches submitted by POST (#32).

I would propose to use a header instead, such as `X-API-Key` suggested by Swagger:
https://swagger.io/docs/specification/authentication/api-keys/

Closes #26.