### PR TITLE
Expose matching features for client-side scoring

### DIFF
--- a/latest/examples/manifest/invalid/feature-view.json
+++ b/latest/examples/manifest/invalid/feature-view.json
@@ -1,0 +1,8 @@
+{
+    "name": "VIAF",
+    "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
+    "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD",
+    "feature_view": {
+        "url": "https://vocab.getty.edu/recon/features/"
+    }
+}

--- a/latest/examples/manifest/valid/feature-view.json
+++ b/latest/examples/manifest/valid/feature-view.json
@@ -1,4 +1,5 @@
 {
+    "versions": ["0.2"],
     "name": "VIAF",
     "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
     "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD",

--- a/latest/examples/manifest/valid/feature-view.json
+++ b/latest/examples/manifest/valid/feature-view.json
@@ -1,0 +1,8 @@
+{
+    "name": "VIAF",
+    "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
+    "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD",
+    "feature_view": {
+        "url": "https://vocab.getty.edu/recon/features/{{id}}"
+    }
+}

--- a/latest/examples/reconciliation-candidate/valid/example.json
+++ b/latest/examples/reconciliation-candidate/valid/example.json
@@ -1,0 +1,34 @@
+{
+  "id": "1117582299",
+  "name": "Urbaniak, Hans-Eberhard",
+  "score": 85.71888,
+  "features": [
+    {
+      "id": "name_tfidf",
+      "value": 378.239
+    },
+    {
+      "id": "pagerank",
+      "value": -3.1209
+    },
+    {
+      "id": "type_match",
+      "value": 10.329
+    },
+    {
+      "id": "deprecated",
+      "value": false
+    }
+  ],
+  "match": true,
+  "type": [
+    {
+      "id": "AuthorityResource",
+      "name": "Normdatenressource"
+    },
+    {
+      "id": "DifferentiatedPerson",
+      "name": "Individualisierte Person"
+    }
+  ]
+}

--- a/latest/examples/reconciliation-result-batch/valid/example-full.json
+++ b/latest/examples/reconciliation-result-batch/valid/example-full.json
@@ -6,6 +6,24 @@
         "name": "Urbaniak, Regina",
         "score": 53.015232,
         "match": false,
+        "features": [
+          {
+            "id": "name_tfidf",
+            "value": 378.239
+          },
+          {
+            "id": "pagerank",
+            "value": -3.1209
+          },
+          {
+            "id": "type_match",
+            "value": 10.329
+          },
+          {
+            "id": "deprecated",
+            "value": false
+          }
+        ],
         "type": [
           {
             "id": "AuthorityResource",
@@ -41,6 +59,24 @@
         "id": "123064325",
         "name": "Schwanhold, Ernst",
         "score": 86.43497,
+        "features": [
+          {
+            "id": "name_tfidf",
+            "value": 334.188
+          },
+          {
+            "id": "pagerank",
+            "value": -4.1581
+          },
+          {
+            "id": "type_match",
+            "value": 13.78
+          },
+          {
+            "id": "deprecated",
+            "value": false
+          }
+        ],
         "match": true,
         "type": [
           {

--- a/latest/index.html
+++ b/latest/index.html
@@ -192,11 +192,16 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
            Moreover, for each <a>property</a> it contains a set of associated <a>property values</a>, possibly empty.
         </p>
         <p>
-           Reconciliation services can define in their <a>service manifest</a> a <dfn>view template</dfn> which
-           associates to each entity a corresponding URI, by inserting its identifier in the template.
+           Reconciliation services can define in their <a>service manifest</a> a <dfn>view template</dfn> for entities,
+           which associates to each entity a corresponding URI, by inserting its identifier in the template.
            A view template is a string which contains the <code>{{id}<!-- -->}</code> substring.
            For each entity, replacing <code>{{id}<!-- -->}</code> in the template by the entity's identifier
            MUST result in a valid URI [[RFC2396]].
+        </p>
+        <p>
+           Similarly, it is possible to associate to each <a>matching feature</a> a URL where documentation about
+           the feature is provided, by means of a view template. Inserting any feature identifier in this template
+           generates the URL for the feature.
         </p>
       </section>
       <section>
@@ -286,7 +291,9 @@ will help disambiguating it from others;</dd>
           <dd>A list of <a>types</a> which are considered sensible default choices as types supplied in reconciliation queries. For services which do not rely on types, this MAY contain a single type with a generic name making it clear that all entities in the
 database are instances of this type.<dd>
           <dt><code>view</code></dt>
-          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>view template</a> for the service;</dd>
+          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>view template</a> for <a>entities</a>;</dd>
+          <dt><code>feature_view</code></td>
+          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>view template</a> for <a>matching features</a>;</dd>
           <dt><code>preview</code></dt>
           <dd>A <a>preview metadata</a>, supplied if the service offers a <a href="#preview-service">preview service</a>;</dd>
           <dt><code>suggest</code></dt>
@@ -415,7 +422,7 @@ database are instances of this type.<dd>
           </dl>
         </p>
         <p>
-          A <dfn>matching feature</dfn> is a numerical value which can be used to determine how likely it is for the candidate to be the correct entity. It contains the following fields:
+          A <dfn>matching feature</dfn> is a numerical or boolean value which can be used to determine how likely it is for the candidate to be the correct entity. It contains the following fields:
           <dl>
             <dt><code>id</code></dt>
             <dd>A string which identifies the feature, such as <code>"name_tfidf"</code> or <code>"pagerank"</code>. This id must be unique among all the matching features returned for a given candidate;</dd>

--- a/latest/index.html
+++ b/latest/index.html
@@ -408,9 +408,27 @@ database are instances of this type.<dd>
 	    <dd>The types of the candidate entity;</dd>
 	    <dt><code>score</code></dt>
 	    <dd>A numeral indicating how well this candidate entity matches the query: a higher score indicates a better match;</dt>
+            <dt><code>features</code></dt>
+            <dd>An optional array of <a>matching features</a>;</dd>
 	    <dt><code>match</code></dt>
             <dd>A boolean matching decision, which indicates whether the service considers this candidate good enough to be chosen as a correct match.</dd>
           </dl>
+        </p>
+        <p>
+          A <dfn>matching feature</dfn> is a numerical value which can be used to determine how likely it is for the candidate to be the correct entity. It contains the following fields:
+          <dl>
+            <dt><code>id</code></dt>
+            <dd>A string which identifies the feature, such as <code>"name_tfidf"</code> or <code>"pagerank"</code>. This id must be unique among all the matching features returned for a given candidate;</dd>
+            <dt><code>value</code></dt>
+            <dd>The value of the feature for the candidate, which can be any boolean or numerical value.</dd>
+          </dl>
+         Multiple matching features are often used in combination to provide the final matching score (available
+in the <code>score</code> field). By exposing individual features in their responses, services make it possible for clients
+         to compute matching scores which fit their use cases better.
+        </p>
+        <p>
+          Example of a <a>reconciliation candidate</a> with all possible fields:
+          <pre data-include="examples/reconciliation-candidate/valid/example.json" class="example json"></pre>
         </p>
         <p>
 	  A <dfn>reconciliation result</dfn> is a set of <a>reconciliation candidates</a>. It is serialized in JSON
@@ -471,9 +489,19 @@ database are instances of this type.<dd>
 	</p>
 	<p>
 	  Deciding on a scoring method is one of the main difficulties in developing a reconciliation service.
-	  Many scoring strategies used in data matching [[christen-2012]] cannot be implemented easily in
-	  the context of this reconciliation API due to the separation of responsibilities between the client
-	  and the server.
+          Services are encouraged to expose as many <a>matching features</a> as they deem useful, in particular
+          features which require knowledge of global statistics on the database or other attributes. Examples include:
+          <dl>
+            <dt>Name matching</dt>
+            <dd>Similarity metrics to compare the entity name and the query;</dd>
+            <dt>Entity popularity</dt>
+            <dd>Metrics which predict how likely an entity is likely to be refered to, regardless of the query supplied;</dd>
+            <dt>Comparison of attributes to query properties</dt>
+            <dd>Obtained using similarity metrics to compare the supplied properties and measure their discriminative power;</dd>
+            <dt>Type matching</dt>
+            <dd>To quantify how well any type supplied in the query corresponds to the candidate's types.</dd>
+          </dl>
+	  By exposing such features, services make it possible for clients to use a wide range of data matching strategies [[christen-2012]]. This also makes the global candidate scores less opaque.
 	</p>
 	<p class="note">
 	  Many open source reconciliation services are available and these might provide some inspiration

--- a/latest/schemas/manifest.json
+++ b/latest/schemas/manifest.json
@@ -39,6 +39,19 @@
         "url"
       ]
     },
+    "feature_view": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "A template to transform a matching feature identifier into the corresponding URI",
+          "pattern": ".*\\{\\{id\\}\\}.*"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
     "defaultTypes": {
       "type": "array",
       "description": "A list of default types that are considered good generic choices for reconciliation",

--- a/latest/schemas/reconciliation-result-batch.json
+++ b/latest/schemas/reconciliation-result-batch.json
@@ -24,6 +24,30 @@
                 "type": "number",
                 "description": "Number indicating how likely it is that the candidate matches the query"
               },
+              "features": {
+                "type": "array",
+                "description": "A list of features which can be used to derive a matching score",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "A unique string identifier for the feature"
+                    },
+                    "value": {
+                      "description": "The value of the feature for this reconciliation candidate",
+                      "oneOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
               "match": {
                 "type": "boolean",
                 "description": "Boolean value indicating whether the candiate is a certain match or not."


### PR DESCRIPTION
This is a fairly simple proposal to expose matching features in reconciliation candidates, for #31.

The idea behind this proposal is that clients would then be able to construct datasets of reconciliation candidates and their features, annotate which candidates are correct, and train some classifier to predict correctness based on the features (and potentially other features computed locally). This relies on the assumption that services return a given feature (designated by its `id`) in many different candidates.

Note that there is no requirement that the global score for a candidate is derived from the individual features in a particular way: services are free to expose features which are not actually used to compute the global score. This seems useful since it lets services expose features which could potentially be useful in some scenarios, but are not used for the main score to keep its computation simple.

The global score is still kept for backwards-compatibility and as it gives a useful baseline for clients to build on (or potentially use it as a feature itself if it isn't already derived from the exposed features).

This JSON syntax is a bit heavy if services want to return hundreds of features for each candidate, but I wanted to avoid using a simple dictionary as it can make implementation in clients harder (#33):
```json
{
   "tfidf": 3498,
   "pagerank": 34.3,
   "type_match": -11.3
}
```

It's obviously quite hard to evaluate what could go wrong without building the corresponding functionality in clients (for instance OpenRefine)… Do you think such an API would work for your use cases?