### PR TITLE
Let services return descriptions in recon and data extension responses

### DIFF
--- a/latest/examples/data-extension-response/valid/example-full.json
+++ b/latest/examples/data-extension-response/valid/example-full.json
@@ -35,7 +35,8 @@
       "professionOrOccupation": [
         {
           "id": "4037223-6",
-          "name": "Malerin"
+          "name": "Malerin",
+          "description": "Beruf"
         },
         {
           "id": "4033430-2",

--- a/latest/examples/reconciliation-result-batch/valid/example-full.json
+++ b/latest/examples/reconciliation-result-batch/valid/example-full.json
@@ -4,6 +4,7 @@
       {
         "id": "120333937",
         "name": "Urbaniak, Regina",
+        "description": "1969-| Diss. Fachbereich Mathematik",
         "score": 53.015232,
         "match": false,
         "type": [
@@ -20,6 +21,7 @@
       {
         "id": "1127147390",
         "name": "Urbaniak, Jan",
+        "description": "Universität Wrocław, Niederlandestudien",
         "score": 52.357353,
         "match": false,
         "type": [
@@ -40,6 +42,7 @@
       {
         "id": "123064325",
         "name": "Schwanhold, Ernst",
+        "description": "1948-| Mitglied des Deutschen Bundestages, SPD (1993)",
         "score": 86.43497,
         "match": true,
         "type": [
@@ -56,6 +59,7 @@
       {
         "id": "116362988X",
         "name": "Schwanhold, Nadine",
+        "description": "Dissertation Potsdam, Universität, Mathematik-Naturwissenschaftliche Fakultät, 2017",
         "score": 62.04763,
         "match": false,
         "type": [

--- a/latest/index.html
+++ b/latest/index.html
@@ -186,6 +186,8 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
              <dd>an identifier, which is a non-empty string. This identifier must be unique among all entities;</dd>
              <dt><code>name</code></dt>
              <dd>a <emph>name</emph>, which is also a non-empty string;</dd>
+             <dt><code>description</code></dt>
+             <dd>an optional <emph>description</emph> as a human-readable string;</dd>
              <dt><code>type</code></dt>
              <dd>a list of <a>types</a>, possibly empty;</dd>
            </dl>
@@ -404,6 +406,8 @@ database are instances of this type.<dd>
 	    <dd>The identifier of the candidate entity;</dd>
 	    <dt><code>name</code></dt>
 	    <dd>The name of the candidate entity;</dd>
+	    <dt><code>description</code></dt>
+	    <dd>The entity description MAY optionally be included;</dd>
 	    <dt><code>type</code></dt>
 	    <dd>The types of the candidate entity;</dd>
 	    <dt><code>score</code></dt>

--- a/latest/schemas/data-extension-response.json
+++ b/latest/schemas/data-extension-response.json
@@ -58,6 +58,9 @@
                       },
                       "name": {
                         "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
                       }
                     },
                     "required": [

--- a/latest/schemas/reconciliation-result-batch.json
+++ b/latest/schemas/reconciliation-result-batch.json
@@ -20,6 +20,10 @@
                 "type": "string",
                 "description": "Entity name of the candidate"
               },
+              "description": {
+                "type": "string",
+                "description": "Optional description of the candidate entity"
+              },
               "score": {
                 "type": "number",
                 "description": "Number indicating how likely it is that the candidate matches the query"


### PR DESCRIPTION
Closes #47.

Descriptions were already supported by the suggest services, this lets services return them in reconciliation and data extension endpoints.

@MatthiasWinkelmann does this fit your bill?