### PR TITLE
URI component encoding for view, preview & flyout templates

### DIFF
--- a/latest/index.html
+++ b/latest/index.html
@@ -216,7 +216,8 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
            which associates to each entity a corresponding URI, by inserting its identifier in the template.
            A view template is a string which contains the <code>{{id}<!-- -->}</code> substring.
            For each entity, replacing <code>{{id}<!-- -->}</code> in the template by the entity's identifier
-           MUST result in a valid URI [[RFC2396]].
+           MUST result in a valid URI. To guarantee the correctness of the formed URI, clients MUST percent-encode
+           component-delimiting reserved characters in the identifier, i.e. encode it as a URI component [[RFC3986]].
         </p>
         <p>
            Similarly, it is possible to associate to each <a>matching feature</a> a URL where documentation about
@@ -558,7 +559,7 @@ in the <code>score</code> field). By exposing individual features in their respo
       <p>Reconciliation services MAY offer a preview service by providing the <dfn>preview metadata</dfn> as an object stored in the <a>service manifest</a> under the key <code>preview</code>. It consists of the following fields, all mandatory:
         <dl>
           <dt><code>url</code></dt>
-          <dd>A string containing <code>{{id}<!-- -->}</code> such that replacing <code>{{id}<!-- -->}</code> by an <a>entity</a> identifier yields the <dfn>preview URL</dfn> for that entity. This preview URL MUST resolve to an HTML page summarizing the entity.
+          <dd>A string containing <code>{{id}<!-- -->}</code> such that replacing <code>{{id}<!-- -->}</code> by an <a>entity</a> identifier encoded as a URI component yields the <dfn>preview URL</dfn> for that entity. This preview URL MUST resolve to an HTML page summarizing the entity.
 It SHOULD render appropriately in an <code>&lt;iframe&gt;</code> whose dimensions are specified by the service in the following fields;</dd>
           <dt><code>width</code></dt>
           <dd>The width in pixels of the <code>&lt;iframe&gt;</code> element where to render an entity preview;</dd>
@@ -685,7 +686,7 @@ It SHOULD render appropriately in an <code>&lt;iframe&gt;</code> whose dimension
         </p>
 	<p>
 	  A preview for a suggested entity, property or type can then be obtained at the flyout endpoint by replacing <code>${id}</code>
-	  by the identifier for the entity, property or type. Upon a GET query to this URL, the service returns a JSON response
+	  by the identifier for the entity, property or type, encoded as a URI component. Upon a GET query to this URL, the service returns a JSON response
 	  consisting of an object with the following fields:
 	  <dl>
 	    <dt><code>id</code></dt>


### PR DESCRIPTION
This corresponds to the implementation in https://github.com/OpenRefine/OpenRefine/pull/3731, which implements this for the view and preview (but not yet for the flyout) URL templates. See https://github.com/reconciliation-api/specs/issues/39#issuecomment-825570330 for the reasoning behind this approach (vs. supporting full URIs as identifiers).