### PR TITLE
Switch to RFC6570 for URI templates

### DIFF
--- a/latest/examples/manifest/valid/codefork-viaf.json
+++ b/latest/examples/manifest/valid/codefork-viaf.json
@@ -4,7 +4,7 @@
   "identifierSpace": "http://rdf.freebase.com/ns/user/hangy/viaf",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
   "view": {
-    "url": "http://viaf.org/viaf/{{id}}"
+    "url": "http://viaf.org/viaf/{id}"
   },
   "defaultTypes": [
     {

--- a/latest/examples/manifest/valid/feature-view.json
+++ b/latest/examples/manifest/valid/feature-view.json
@@ -4,6 +4,6 @@
     "identifierSpace": "http://vocab.getty.edu/doc/#GVP_URLs_and_Prefixes",
     "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD",
     "feature_view": {
-        "url": "https://vocab.getty.edu/recon/features/{{id}}"
+        "url": "https://vocab.getty.edu/recon/features/{id}"
     }
 }

--- a/latest/examples/manifest/valid/findthatcharity.json
+++ b/latest/examples/manifest/valid/findthatcharity.json
@@ -4,10 +4,10 @@
   "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
   "view": {
-    "url": "https://findthatcharity.uk/charity/{{id}}"
+    "url": "https://findthatcharity.uk/charity/{id}"
   },
   "preview": {
-    "url": "https://findthatcharity.uk/preview/charity/{{id}}",
+    "url": "https://findthatcharity.uk/preview/charity/{id}",
     "width": 430,
     "height": 300
   },

--- a/latest/examples/manifest/valid/geocollider-sinatra.json
+++ b/latest/examples/manifest/valid/geocollider-sinatra.json
@@ -4,7 +4,7 @@
   "schemaSpace": "https://pleiades.stoa.org/places/",
   "identifierSpace": "https://pleiades.stoa.org/places/vocab#",
   "view": {
-    "url": "{{id}}"
+    "url": "{+id}"
   },
   "suggest": {
     "property": {

--- a/latest/examples/manifest/valid/getty.json
+++ b/latest/examples/manifest/valid/getty.json
@@ -22,7 +22,7 @@
   "name": "Getty Vocabularies Reconciliation Service",
   "preview": {
     "height": 200,
-    "url": "https://services.getty.edu/vocab/reconcile/preview?id={{id}}",
+    "url": "https://services.getty.edu/vocab/reconcile/preview{?id}",
     "width": 350
   },
   "schemaSpace": "http://vocab.getty.edu/doc/#The_Getty_Vocabularies_and_LOD",
@@ -33,6 +33,6 @@
     }
   },
   "view": {
-    "url": "http://vocab.getty.edu/page/{{id}}"
+    "url": "http://vocab.getty.edu/page/{id}"
   }
 }

--- a/latest/examples/manifest/valid/kerameikos.json
+++ b/latest/examples/manifest/valid/kerameikos.json
@@ -2,7 +2,7 @@
   "versions": ["0.2"],
   "name": "Kerameikos.org",
   "view": {
-    "url": "http://kerameikos.org/id/{{id}}"
+    "url": "http://kerameikos.org/id/{id}"
   },
   "identifierSpace": "http://kerameikos.org/id/",
   "schemaSpace": "http://kerameikos.org/ontology",
@@ -61,7 +61,7 @@
     }
   ],
   "preview": {
-    "url": "http://kerameikos.org/apis/reconcile/preview?id={{id}}",
+    "url": "http://kerameikos.org/apis/reconcile/preview{?id}",
     "height": 90,
     "width": 320
   },
@@ -69,7 +69,7 @@
     "entity": {
       "service_url": "http://kerameikos.org/apis/reconcile",
       "service_path": "/suggest/entity",
-      "flyout_service_path": "/flyout?id=${id}"
+      "flyout_service_path": "/flyout{?id}"
     }
   }
 }

--- a/latest/index.html
+++ b/latest/index.html
@@ -212,16 +212,21 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
            Moreover, for each <a>property</a> it contains a set of associated <a>property values</a>, possibly empty.
         </p>
         <p>
-           Reconciliation services can define in their <a>service manifest</a> a <dfn>view template</dfn> for entities,
-           which associates to each entity a corresponding URI, by inserting its identifier in the template.
-           A view template is a string which contains the <code>{{id}<!-- -->}</code> substring.
-           For each entity, replacing <code>{{id}<!-- -->}</code> in the template by the entity's identifier
-           MUST result in a valid URI. To guarantee the correctness of the formed URI, clients MUST percent-encode
-           component-delimiting reserved characters in the identifier, i.e. encode it as a URI component [[RFC3986]].
+           Reconciliation services can define in their <a>service manifest</a> a <dfn>URI template</dfn> for entities,
+           as defined by [[RFC6570]]. This URI template builds a view URI for each entity, and has <code>id</code> as only variable.
+           For each entity, expanding the template with <code>id</code> being set to the entity's identifier
+           MUST result in a valid URI.
+        </p>
+        <p>
+           For example, a service which uses Wikidata identifiers for its entities could use <code>http://www.wikidata.org/entity/{id}</code>
+           as URI template for entities. For an entity with identifier <code>Q5</code>, this would expand to <code>http://www.wikidata.org/entity/Q5</code>.
+           Services for which the entity's identifier is already a full URI can use the <code>{+id}</code> template, which disables the escaping of some characters
+           when inserting the identifier in the template.
+           See [[RFC6570]] for more examples of URI templates.   
         </p>
         <p>
            Similarly, it is possible to associate to each <a>matching feature</a> a URL where documentation about
-           the feature is provided, by means of a view template. Inserting any feature identifier in this template
+           the feature is provided, by means of a URI template. Inserting any feature identifier in this template
            generates the URL for the feature.
         </p>
       </section>
@@ -322,9 +327,9 @@ will help disambiguating it from others;</dd>
           <dd>An array of <a>types</a> which are considered sensible default choices as types supplied in reconciliation queries. For services which do not rely on types, this MAY contain a single type with a generic name making it clear that all entities in the
 database are instances of this type.<dd>
           <dt><code>view</code></dt>
-          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>view template</a> for <a>entities</a>;</dd>
+          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>URI template</a> for <a>entities</a>;</dd>
           <dt><code>feature_view</code></td>
-          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>view template</a> for <a>matching features</a>;</dd>
+          <dd>An optional object which contains a single field <code>url</code>. Its value is a <a>URI template</a> for <a>matching features</a>;</dd>
           <dt><code>preview</code></dt>
           <dd>A <a>preview metadata</a>, supplied if the service offers a <a href="#preview-service">preview service</a>;</dd>
           <dt><code>suggest</code></dt>
@@ -565,7 +570,7 @@ in the <code>score</code> field). By exposing individual features in their respo
       <p>Reconciliation services MAY offer a preview service by providing the <dfn>preview metadata</dfn> as an object stored in the <a>service manifest</a> under the key <code>preview</code>. It consists of the following fields, all mandatory:
         <dl>
           <dt><code>url</code></dt>
-          <dd>A string containing <code>{{id}<!-- -->}</code> such that replacing <code>{{id}<!-- -->}</code> by an <a>entity</a> identifier encoded as a URI component yields the <dfn>preview URL</dfn> for that entity. This preview URL MUST resolve to an HTML page summarizing the entity.
+          <dd>A URI template containing the <code>id</code> variable such that expanding the template with <code>id</code> set to an <a>entity</a> identifier yields the <dfn>preview URL</dfn> for that entity. This preview URL MUST resolve to an HTML page summarizing the entity.
 It SHOULD render appropriately in an <code>&lt;iframe&gt;</code> whose dimensions are specified by the service in the following fields;</dd>
           <dt><code>width</code></dt>
           <dd>The width in pixels of the <code>&lt;iframe&gt;</code> element where to render an entity preview;</dd>

--- a/latest/schemas/manifest.json
+++ b/latest/schemas/manifest.json
@@ -32,7 +32,7 @@
         "url": {
           "type": "string",
           "description": "A template to transform an entity identifier into the corresponding URI",
-          "pattern": ".*\\{\\{id\\}\\}.*"
+          "pattern": ".*\\{.*id.*\\}.*"
         }
       },
       "required": [
@@ -45,7 +45,7 @@
         "url": {
           "type": "string",
           "description": "A template to transform a matching feature identifier into the corresponding URI",
-          "pattern": ".*\\{\\{id\\}\\}.*"
+          "pattern": ".*\\{.*id.*\\}.*"
         }
       },
       "required": [
@@ -76,7 +76,7 @@
             },
             "flyout_service_path": {
               "type": "string",
-              "pattern": ".*\\$\\{id\\}.*"
+              "pattern": ".*\\{.*id.*\\}.*"
             }
           },
           "required": []
@@ -100,7 +100,7 @@
       "properties": {
         "url": {
           "type": "string",
-          "pattern": ".*\\{\\{id\\}\\}.*",
+          "pattern": ".*\\{.*id.*\\}.*",
           "description": "A URL pattern which transforms the entity ID into a preview URL for it"
         },
         "width": {


### PR DESCRIPTION
Closes #39.

This switches to the RFC6570 syntax for URI templates, as suggested in #39 by @Robsteranium.
This has the benefit of not forcing URL encoding of the identifiers when inserting them in the template, and allowing for a much wider range of use cases. This is a significant change since the syntax used so far (`{{id}}` in most places, `${id}` for the flyout template) are not compatible with RFC6570. However I think it is really important to support the use case of services using a full URI as identifier (since that is already happening in the wild), or parts of URI which should be inserted without escaping.