### PR TITLE
Add support for returning entities that are understood by other services

### DIFF
--- a/latest/examples/data-extension-query/valid/example-full.json
+++ b/latest/examples/data-extension-query/valid/example-full.json
@@ -19,6 +19,9 @@
     },
     {
       "id": "professionOrOccupation"
+    },
+    {
+      "id": "wikidataId"
     }
   ]
 }

--- a/latest/examples/data-extension-response/valid/example-full.json
+++ b/latest/examples/data-extension-response/valid/example-full.json
@@ -15,6 +15,11 @@
         "id": "SubjectHeading",
         "name": "Schlagwort"
       }
+    },
+    {
+      "id": "wikidataId",
+      "name": "Wikidata ID",
+      "service": "https://www.wikidata.org/api/reconcile"
     }
   ],
   "rows": {
@@ -42,6 +47,12 @@
           "id": "4033430-2",
           "name": "Künstlerin"
         }
+      ],
+      "wikidataId": [
+        {
+          "id": "Q3874347",
+          "name": "Gerda Stryi-Leitgeb"
+        }
       ]
     },
     "1064905412": {
@@ -57,6 +68,12 @@
         {
           "id": "4002844-6",
           "name": "Architekt"
+        }
+      ],
+      "wikidataId": [
+        {
+          "id": "Q3874347",
+          "name": "Gerda Stryi-Leitgeb"
         }
       ]
     }

--- a/latest/index.html
+++ b/latest/index.html
@@ -852,7 +852,9 @@ It SHOULD render appropriately in an <code>&lt;iframe&gt;</code> whose dimension
           The <dfn id="data+extension+response+rows">rows</dfn> object contains, for each <a>entity</a> identifier in the
           <a>data extension query</a>, for each <a>property</a> identifier in the
           <a href="#data+extension+response+metadata">metadata</a>, the <a>property values</a> of that property in that entity.
-          If the property values are <a>entities</a>, their identifiers MUST be in the service's <a>identifier space</a>.
+          If the property values are <a>entities</a>, their identifiers are expected to be in the service's <a>identifier space</a>.
+          If that is not the case, the service MUST specify in the <code>meta</code> section the endpoint of another reconciliation service whose <a>identifier space</a>
+          contains the returned entities. This endpoint is specified on a column-per-column basis.
         </p>
         <p>
           Response example for the <a>data extension query</a> from the previous example:

--- a/latest/schemas/data-extension-response.json
+++ b/latest/schemas/data-extension-response.json
@@ -28,6 +28,11 @@
             "required": [
               "id"
             ]
+          },
+          "service": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^https?://"
           }
         },
         "required": [


### PR DESCRIPTION
This adds a new field to data extension responses, to let them return entities which belong to the identifier space of another service. I made the choice of returning a reconciliation endpoint rather than an identifier space, because I think this is going to be more useful to users (if they want to keep doing data extension with the new endpoint). But I think one can also make a case for supplying the identifier space (to let the user pick which reconciliation service they want to use for this identifier space).

Closes #75.