### PR TITLE
Add Accept-Language and Content-Language headers

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -462,7 +462,7 @@ database are instances of this type.<dd>
         </p>
         <p>
           Examples of user-facing text in service responses are: the name of the service and the name of property configuration fields in the manifest, the name and description of entities, types and properties,
-          the contents of the entity preview pages.
+          the contents of the entity preview pages, and the documentation linked in the manifest.
         </p>
       </section>
       <section>

--- a/draft/index.html
+++ b/draft/index.html
@@ -455,6 +455,17 @@ database are instances of this type.<dd>
         </p>
       </section>
       <section>
+        <h3>Language Selection</h3>
+        <p>
+           Following [[RFC9110]], services SHOULD use the <code>Accept-Language</code> header to let clients select the language in which user-facing text is returned.
+           They SHOULD use the <code>Content-Language</code> in their responses to expose the language each response is returned in.
+        </p>
+        <p>
+          Examples of user-facing text in service responses are: the name of the service and the name of property configuration fields in the manifest, the name and description of entities, types and properties,
+          the contents of the entity preview pages.
+        </p>
+      </section>
+      <section>
         <h3>Error Handling and Rate-limiting</h3>
         <p>
            Services SHOULD use the broad spectrum of HTTP status codes [[RFC2616]] [[RFC6585]] to


### PR DESCRIPTION
For #52.

There seems to be interest in #52 to have more than that: also introduce parameters in the queries to specify the language of the data. I am not too sure how useful that is and which form it should take (do you want to specify the language of each string in the query independently? should we follow JSON-LD conventions to represent strings with languages?) so I am leaving this for another PR.