### PR TITLE
Mark 0.1 and 0.2 as final reports

### DIFF
--- a/0.1/index.html
+++ b/0.1/index.html
@@ -5,7 +5,7 @@
     <script src='../libs/respec-w3c.js' async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
-        specStatus: "CG-DRAFT",
+        specStatus: "CG-FINAL",
         subtitle: "A protocol for data matching on the Web",
         pluralize: true,
 	doJsonLd: true,
@@ -13,7 +13,7 @@
         wgPublicList: "public-reconciliation",
         wgURI: "https://www.w3.org/community/reconciliation/",
 	canonicalURI: "https://reconciliation-api.github.io/specs/0.1/",
-	edDraftURI: "https://reconciliation-api.github.io/specs/latest/",
+	edDraftURI: "https://reconciliation-api.github.io/specs/draft/",
 	license: "w3c-software-doc",
         github: {
            repoURL: "https://github.com/reconciliation-api/specs",
@@ -66,19 +66,11 @@
       <p>
         This document describes the reconciliation service API, as implemented in OpenRefine 2.8 to 3.2.
         It is intended as a comprehensive and definitive specification of this API in its given state.
-	Various aspects of this API need to be improved, as hinted by notes throughout this document,
-	and by the choice of the version number 0.1 indicating an early development stage.
-	Further improvements to the API, to be discussed in the
+	This is mostly of historical interest since newer versions are available and already widely adopted by both clients and services.
+	Further improvements to the API, coordinated by the
 	<a href="https://www.w3c.org/community/reconciliation/">W3C Entity Reconciliation Community Group</a>,
-	will be specified in <a href="https://reconciliation-api.github.io/specs/latest/">the next iteration of this document</a>.
-      </p>
-    </section>
-    <section id='sotd'>
-      <p>
-        Members of the Community Group are encouraged to contribute to this document by
-        documenting the current behaviour of the reconciliation API.
-        The <a href="https://github.com/w3c/respec/wiki/ReSpec-Editor's-Guide">ReSpec Editor's Guide</a>
-        can be used to learn more about the markup to use in this document.
+	have been specified in <a href="https://reconciliation-api.github.io/specs/0.2/">the next iteration of this document</a>,
+        which we encourage services to follow instead.
       </p>
     </section>
     <section class="informative">

--- a/0.2/index.html
+++ b/0.2/index.html
@@ -5,7 +5,7 @@
     <script src='../libs/respec-w3c.js' async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
-        specStatus: "CG-DRAFT",
+        specStatus: "CG-FINAL",
         subtitle: "A protocol for data matching on the Web",
         pluralize: true,
 	doJsonLd: true,
@@ -13,7 +13,7 @@
         wgPublicList: "public-reconciliation",
         wgURI: "https://www.w3.org/community/reconciliation/",
 	canonicalURI: "https://reconciliation-api.github.io/specs/0.2/",
-	edDraftURI: "https://reconciliation-api.github.io/specs/latest/",
+	edDraftURI: "https://reconciliation-api.github.io/specs/draft/",
 	prevRecURI: "https://reconciliation-api.github.io/specs/0.1/",
 	license: "w3c-software-doc",
         github: {


### PR DESCRIPTION
For #112.

We should publish 0.1 and 0.2 on the W3C website after that. I can take care of it.