### PR TITLE
Change remaining URI templates in examples to RFC6570 syntax

### DIFF
--- a/draft/examples/manifest/invalid/godot-missing-identifierSpace.json
+++ b/draft/examples/manifest/invalid/godot-missing-identifierSpace.json
@@ -7,9 +7,9 @@
   ],
   "name": "GODOT (Graph of Dated Objects and Texts) Reconciliation Service - Roman Consulates",
   "preview": {
-    "url": "https://godot.date/reconcile/preview={{id}}"
+    "url": "https://godot.date/reconcile/preview={id}"
   },
   "view": {
-    "url": "https://godot.date/id/{{id}}"
+    "url": "https://godot.date/id/{id}"
   }
 }

--- a/draft/examples/manifest/invalid/opencorporates.json
+++ b/draft/examples/manifest/invalid/opencorporates.json
@@ -3,10 +3,10 @@
   "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
   "view": {
-    "url": "https://opencorporates.com{{id}}"
+    "url": "https://opencorporates.com{id}"
   },
   "preview": {
-    "url": "https://opencorporates.com{{id}}/preview",
+    "url": "https://opencorporates.com{id}/preview",
     "width": 430,
     "height": 300
   },

--- a/draft/examples/manifest/invalid/ror-invalid-view-pattern.json
+++ b/draft/examples/manifest/invalid/ror-invalid-view-pattern.json
@@ -13,7 +13,7 @@
   },
   "suggest": {
     "entity": {
-      "flyout_service_path": "/flyout?id=${id}",
+      "flyout_service_path": "/flyout?id={id}",
       "service_path": "/suggest",
       "service_url": "https://reconcile.ror.org"
     }
@@ -21,6 +21,6 @@
   "preview": {
     "width": 400,
     "height": 100,
-    "url": "https://reconcile.ror.org/preview/{{id}}"
+    "url": "https://reconcile.ror.org/preview/{id}"
   }
 }

--- a/draft/examples/manifest/invalid/slub-invalid-property-setting.json
+++ b/draft/examples/manifest/invalid/slub-invalid-property-setting.json
@@ -63,11 +63,11 @@
   "name": "SLUB LOD reconciliation for OpenRefine",
   "preview": {
     "height": 100,
-    "url": "http://data.slub-dresden.de/{{id}}.preview",
+    "url": "http://data.slub-dresden.de/{id}.preview",
     "width": 320
   },
   "schemaSpace": "http://schema.org",
   "view": {
-    "url": "http://data.slub-dresden.de/{{id}}"
+    "url": "http://data.slub-dresden.de/{id}"
   }
 }

--- a/draft/examples/manifest/valid/authentication.json
+++ b/draft/examples/manifest/valid/authentication.json
@@ -1,7 +1,7 @@
 {
   "versions": [ "0.2" ],
   "view": {
-    "url": "http://vivo.med.cornell.edu/individual?uri={{id}}"
+    "url": "http://vivo.med.cornell.edu/individual?uri={id}"
   },
   "identifierSpace": "http://vivo.med.cornell.edu/individual/",
   "name": "VIVO Reconciliation Service",

--- a/draft/examples/manifest/valid/kew.json
+++ b/draft/examples/manifest/valid/kew.json
@@ -4,10 +4,10 @@
   "identifierSpace": "http://ipni.org/urn:lsid:ipni.org:names:",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
   "view": {
-    "url": "http://ipni.org/urn:lsid:ipni.org:names:{{id}}"
+    "url": "http://ipni.org/urn:lsid:ipni.org:names:{id}"
   },
   "preview": {
-    "url": "http://ipni.org/urn:lsid:ipni.org:names:{{id}}",
+    "url": "http://ipni.org/urn:lsid:ipni.org:names:{id}",
     "width": 400,
     "height": 400
   },

--- a/draft/examples/manifest/valid/lobid-gnd.json
+++ b/draft/examples/manifest/valid/lobid-gnd.json
@@ -44,7 +44,7 @@
     }
   ],
   "view": {
-    "url": "https://lobid.org/gnd/{{id}}"
+    "url": "https://lobid.org/gnd/{id}"
   },
   "preview": {
     "height": 100,

--- a/draft/examples/manifest/valid/nomisma.json
+++ b/draft/examples/manifest/valid/nomisma.json
@@ -2,7 +2,7 @@
   "versions": ["0.2"],
   "name": "Nomisma.org",
   "view": {
-    "url": "http://nomisma.org/id/{{id}}"
+    "url": "http://nomisma.org/id/{id}"
   },
   "identifierSpace": "http://nomisma.org/id/",
   "schemaSpace": "http://nomisma.org/ontology",

--- a/draft/examples/manifest/valid/occrp.json
+++ b/draft/examples/manifest/valid/occrp.json
@@ -4,7 +4,7 @@
   "identifierSpace": "http://rdf.freebase.com/ns/type.object.id",
   "schemaSpace": "http://rdf.freebase.com/ns/type.object.id",
   "view": {
-    "url": "https://aleph.occrp.org/entities/{{id}}"
+    "url": "https://aleph.occrp.org/entities/{id}"
   },
   "preview": {
     "width": 800,

--- a/draft/examples/manifest/valid/ordnance-survey.json
+++ b/draft/examples/manifest/valid/ordnance-survey.json
@@ -4,6 +4,6 @@
   "identifierSpace": "http://data.ordnancesurvey.co.uk/id/data/code-point-open",
   "schemaSpace": "http://data.ordnancesurvey.co.uk/id/data/code-point-open",
   "view": {
-    "url": "{{id}}"
+    "url": "{+id}"
   }
 }

--- a/draft/examples/manifest/valid/vivo-cornell.json
+++ b/draft/examples/manifest/valid/vivo-cornell.json
@@ -1,7 +1,7 @@
 {
   "versions": ["0.2"],
   "view": {
-    "url": "http://vivo.med.cornell.edu/individual?uri={{id}}"
+    "url": "http://vivo.med.cornell.edu/individual?uri={id}"
   },
   "identifierSpace": "http://vivo.med.cornell.edu/individual/",
   "name": "VIVO Reconciliation Service",

--- a/draft/examples/manifest/valid/wikidata.json
+++ b/draft/examples/manifest/valid/wikidata.json
@@ -77,7 +77,7 @@
     }
   ],
   "view": {
-    "url": "https://www.wikidata.org/wiki/{{id}}"
+    "url": "https://www.wikidata.org/wiki/{id}"
   },
   "suggest": {
     "type": true,


### PR DESCRIPTION
While working on #140 , I noticed that some of the examples still use legacy view template syntax, i.e. `{{id}}` instead of `{id}` or `{+id}`. Some of the examples had been changed in #85 (that implemented #39), but not all of them. This fixes the remaining ones as well. I assume that this is what we want, to keep the examples in sync with the spec?