### PR TITLE
Fix inconsistent data extension metadata example

### DIFF
--- a/draft/examples/data-extension-metadata/valid/example-full.json
+++ b/draft/examples/data-extension-metadata/valid/example-full.json
@@ -1,8 +1,5 @@
 {
-  "propose_properties": {
-    "service_url": "https://lobid.org",
-    "service_path": "/gnd/reconcile/properties"
-  },
+  "propose_properties": true,
   "property_settings": [
     {
       "name": "limit",


### PR DESCRIPTION
The associated schema (in the manifest) is already up to date.
That's not caught by our CI because we don't have a schema only for data extension metadata, but for the whole manifest instead.

Follow-up to #91.