### PR TITLE
Fix #174 Improve grammar in Entity concept

### DIFF
--- a/draft/index.html
+++ b/draft/index.html
@@ -270,9 +270,8 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
              <dd>an optional <emph>description</emph> as a human-readable string;</dd>
              <dt><code>type</code></dt>
              <dd>an array of <a>types</a>, possibly empty;</dd>
-             <dt><code>properties</code></dt>
-             <dd>an array of <a>property</a> fields and associated <a>property values</a> for the entity, possibly empty;</dd>
            </dl>
+           Moreover, for each <a>property</a> the entity contains a set of associated <a>property values</a>, possibly empty.
         </p>
         <p>
            Reconciliation services MUST define in their <a>service manifest</a> a <dfn>URI template</dfn> for entities,

--- a/draft/index.html
+++ b/draft/index.html
@@ -270,8 +270,9 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
              <dd>an optional <emph>description</emph> as a human-readable string;</dd>
              <dt><code>type</code></dt>
              <dd>an array of <a>types</a>, possibly empty;</dd>
+             <dt><code>properties</code></dt>
+             <dd>an array of <a>property</a> fields and associated <a>property values</a> for the entity, possibly empty;</dd>
            </dl>
-           Moreover, for each <a>property</a> it contains a set of associated <a>property values</a>, possibly empty.
         </p>
         <p>
            Reconciliation services MUST define in their <a>service manifest</a> a <dfn>URI template</dfn> for entities,


### PR DESCRIPTION
Fixes #174 
I also don't think we need the sentence after this:
> Moreover, for each property it contains a set of associated property values, possibly empty.