### PR TITLE
Proposal: Structured Previews

### DIFF
--- a/1.0-draft/examples/structured-preview-response/valid/example.json
+++ b/1.0-draft/examples/structured-preview-response/valid/example.json
@@ -1,0 +1,11 @@
+{
+	"id": "http://www.wikidata.org/entity/Q2",
+	"name": "Earth",
+	"description": "third planet from the Sun in the Solar System",
+	"url": "https://www.wikidata.org/wiki/Q2",
+	"image": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/The_Blue_Marble_%285052124705%29.jpg/330px-The_Blue_Marble_%285052124705%29.jpg",
+	"tags": [
+		["terrestrial planet", "http://www.wikidata.org/entity/Q128207"],
+		["inner planet of the Solar System", "http://www.wikidata.org/entity/Q3504248"]
+	]
+}

--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -54,6 +54,10 @@
             company: "National Library of Finland",
             companyURL: "https://www.kansalliskirjasto.fi/en"
           },
+          {
+            name: "Albin Larsson",
+            url: "https://byabbe.se/",
+          }
           // add yourself here!
           {
             name: "Add Yourself Here!"
@@ -698,6 +702,46 @@ in the <code>score</code> field). By exposing individual features in their respo
        <pre data-include="examples/preview-response/example.html" data-include-format="text" class="example html">
        </pre>
       </p>
+      </section>
+    </section>
+    <section>
+      <h2>Structured Preview Service</h2>
+      <p>
+        This section specifies how reconciliation services can provide previews of their entities in a structured format.
+      </p>
+      <section>
+        <h3>Structured Preview Endpoint</h3>
+        <p>
+          When supported, the structured preview service is queried by resolving the URI template <code>/structured-preview?id={id}</code> relative to the reconciliation endpoint, where <code>id</code> is subsituted by the <a>entity</a> identifier.
+        </p>
+      </section>
+      <section>
+        <h3>Structured Preview Responses</h3>
+        <p>
+          A response to a structured preview query must be a JSON object with the following fields describing the entity:
+          <dl>
+            <dt><code>id</code></dt>
+            <dd>The identifier of the entity;</dd>
+            <dt><code>name</code></dt>
+            <dd>Its corresponding human-readable name, to be displayed prominently to the user;</dd>
+          </dl>
+
+          The response may also contain the following optional fields:
+          <dl>
+            <dt><code>description</code></dt>
+            <dd>An optional description which can be provided to disambiguate namesakes, providing more context. This could for instance be displayed underneath the <code>name</code>;</dd>
+            <dt><code>url</code></dt>
+            <dd>An optional URL to a page with more information about the entity;</dd>
+            <dt><code>image</code></dt>
+            <dd>An optional URL to an image representing the entity;</dd>
+            <dt><code>tags</code></dt>
+            <dd>An optional list of tags and optionally an URL associated with each tag. Tags can represent entity types, categories among other things;</dd>
+          </dl>
+        </p>
+        <p>
+          For instance, a structured preview service could return the following response:
+          <pre data-include="examples/structured-preview-response/valid/example.json" class="example json"></pre>
+        </p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
## Abstract

This proposal introduces a JSON-based alternative to the existing HTML previews with the intent to allow clients to control the user experience and presentation of said previews. A secondary intent is to make it possible to utilize previews in environments where HTML rendering might not be convenient (terminals, etc).

## Status of this Proposal

This proposal reflects our experimental usage rather than the expected end result. For concerns we already have in mind, see the open questions below. If the group considers this a worthy proposal we intend to keep our experiments and this proposal in sync.

## Background and Motivation

We use a few hundred reconciliation services and even though we run all services ourselves using a few shared frameworks the look and feel of the HTML previews have diverted over the years.

In addition to the issue above the client has no control(in a sane and safe way) over the look and functionality of the embedded HTML preview causing user settings related to; keyboard shortcuts, dark mode, font size, etc to differ between the client and the preview. 

We can avoid some of these issues as we run all services ourselves and have our own clients, however, new problems arise with third-party clients as we do so. For example, many of our HTML previews now support dark-mode natively but OpenRefine(.org) does not, causing previews to use a different theme. With structured previews, we want to give the power of controlling theming and much more to clients like OpenRefine.

Another lesser use case is our wish to use the information provided by preview endpoints in our CLI, where HTML rendering is not an option.

Upstreaming this extension would allow our public reconciliation services to remain compatible with OpenRefine and other clients even as we deprecate HTML previews.

## Open Questions and Known Issues

 - The endpoint/capability is not currently announced by the service manifest. 
 - The `image` property should possibly be `media` and contain additional information needed to render it safely.
 - The `tags` property should possibly be replaced by `types`(in our implementations "type" is always 1:1 with RDF entities, the "tags" wording gives us more flexibility in how we use it, but I don't think our use matches that of most)
 - One could argue that HTML previews should be deprecated altogether given the burden of sandboxing and CSPs. However, they are powerful and might still have their use cases.
 - We imagine that there is a need for custom properties and that such an extension mechanism should maybe be a part of the specification.
 - JSON schemas are missing.
 - Error responses and error schemas.
