### PR TITLE
Add paragraph on multi-lingual reconciliation candidates (#138)

### DIFF
--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -580,6 +580,10 @@ database are instances of this type.<dd>
           </dl>
         </p>
         <p>
+          To propose multi-lingual candidates to the client, the reconciliation service MAY return multiple candidates with identical <code>id</code>, but different names, <a href="#text-processing-language">text processing languages</a> or <a href="#text-direction">text directions</a>.
+          The client MAY render these candidates as a single entity, but SHOULD include details from all candidates, so users can comprehend why the entity is being proposed.
+        </p>
+        <p>
           A <dfn>matching feature</dfn> is a numerical or boolean value which can be used to determine how likely it is for the candidate to be the correct entity. It contains the following fields:
           <dl>
             <dt><code>id</code></dt>


### PR DESCRIPTION
See #138.

As discussed in our [November meeting](https://etherpad.lobid.org/p/reconciliation-november-2024#L21), this adds a  paragraph on implementing multi-lingual reconciliation candidates using the current draft spec (replaces https://github.com/reconciliation-api/specs/pull/176, see https://github.com/reconciliation-api/specs/issues/138#issuecomment-2405475863 and following comments for background discussion).