### PR TITLE
Add 'image' field to entities

### DIFF
--- a/1.0-draft/examples/suggest-entities-response/valid/example.json
+++ b/1.0-draft/examples/suggest-entities-response/valid/example.json
@@ -3,6 +3,7 @@
     {
       "name": "cumulonimbus",
       "description": "genus of clouds, dense towering vertical cloud associated with thunderstorms and atmospheric instability",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Anvil_shaped_cumulus_panorama_edit.jpg/640px-Anvil_shaped_cumulus_panorama_edit.jpg",
       "id": "Q182311",
       "notable": [
 	 {

--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -275,6 +275,8 @@ href="https://github.com/OpenRefine/OpenRefine/wiki/Reconciliable-Data-Sources">
              <dd>a <emph>name</emph>, which is also a non-empty string;</dd>
              <dt><code>description</code></dt>
              <dd>an optional <emph>description</emph> as a human-readable string;</dd>
+             <dt><code>image</code></dt>
+             <dd>an optional URL of an <emph>image</emph> which illustrates the entity;</dd>
              <dt><code>type</code></dt>
              <dd>an array of <a>types</a>, possibly empty;</dd>
            </dl>
@@ -761,6 +763,8 @@ in the <code>score</code> field). By exposing individual features in their respo
               <dd>Its corresponding human-readable name, to be displayed prominently to the user;</dd>
               <dt><code>description</code></dt>
               <dd>An optional description which can be provided to disambiguate namesakes, providing more context. This could for instance be displayed underneath the <code>name</code>;</dd>
+              <dt><code>image</code></dt>
+              <dd>An optional URL to an image illustrating the entity, helping the user identify the entity visually. This image could for instance be displayed alongside the <code>name</code> and <code>description</code>;</dd>
 	      <dt><code>notable</code></dt>
 	      <dd>When suggesting entities only, this field can be used to supply some important types (not necessarily all types) of the suggested entity. The value must be an array of either type identifiers (as strings) or type objects, containing an <code>id</code> and <code>name</code> field which represent the type.</dd>
               <dt><code>matchQualifiers</code></dt>

--- a/1.0-draft/schemas/reconciliation-result-batch.json
+++ b/1.0-draft/schemas/reconciliation-result-batch.json
@@ -30,6 +30,10 @@
                   "type": "string",
                   "description": "Optional description of the candidate entity"
                 },
+                "image": {
+                  "type": "string",
+                  "description": "Optional URL of an image illustrating the entity"
+                },
                 "score": {
                   "type": "number",
                   "description": "Number indicating how likely it is that the candidate matches the query"

--- a/1.0-draft/schemas/suggest-entities-response.json
+++ b/1.0-draft/schemas/suggest-entities-response.json
@@ -21,6 +21,10 @@
             "type": "string",
             "description": "An optional description which can be provided to disambiguate namesakes, providing more context."
           },
+          "image": {
+            "type": "string",
+            "description": "An optional URL of an image which illustrates the entity, letting users identify it visually."
+          },
           "notable": {
             "type": "array",
             "description": "Types the suggest entity belongs to",


### PR DESCRIPTION
This PR adds an `image` field to entities so that those can be displayed in a controlled way, without relying on embedding the preview as an iframe.

This is an attempt at offering an alternative approach to #182, as discussed there.