### PR TITLE
Suggest services MUST return the entity if an id is provided

### DIFF
--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -791,8 +791,8 @@ in the <code>score</code> field). By exposing individual features in their respo
       <section class="informative">
         <h3>General Expectations about Suggest Services</h3>
         <p>
-          It is generally expected by users that an entity suggest query where <code>prefix</code> is the name of an entity should return this entity in the suggest response, unless that entity is hidden behind many other namesakes.
-          Similarly, supplying an entity identifier as <code>prefix</code> should return this entity in the suggest response. 
+          It is generally expected by users that an entity suggest query where <code>prefix</code> is the name of an entity SHOULD return this entity in the suggest response, unless that entity is hidden behind many other namesakes.
+          Similarly, supplying an entity identifier as <code>prefix</code> MUST return this entity in the suggest response. 
           Analogous expectations apply for property and type suggest services.
         </p>
         <p>


### PR DESCRIPTION
For #182.

It turns out we were already mandating that suggest services return a given entity if its id is passed as `prefix`, but we weren't using the RFC 2119 terms. This PR changes that to make it easier for clients to rely on this feature.