### PR TITLE
Add `lang` & `dir` to all relevant schemas

### DIFF
--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -961,7 +961,7 @@ containing a type identifier.
 
         <p>All objects used in this protocol (entities, types, properties, queries, candidates, features, etc.) MAY declare an explicit <a>text-processing language</a> in a <code>lang</code> field.
         The <code>lang</code> value MUST be a single valid (i.e. found in the [[IANA Language Subtag Registry]]) [[BCP 47]] language tag. This text-processing language applies to the natural language fields of the object: <code>name</code>, <code>description</code>,
-        <code>query</code> (for <a>reconciliation queries</a>), <code>v</code> and <code>str</code> (for <a>property values</a>). Nested objects inherit the text-processing language of their parent, and can override it by setting their own <code>lang</code> value
+        <code>query</code> (for <a>reconciliation queries</a>), <code>v</code> and <code>str</code> (for <a>property values</a>), <code>helpText</code> (for <a>data extension property settings</a>). Nested objects inherit the text-processing language of their parent, and can override it by setting their own <code>lang</code> value
         (see example below). A default text-processing language for any natural language string returned or processed by a service MAY be set in the <code>lang</code> field of the <a href="#service-manifest">service manifest</a>.
         Client and service implementors SHOULD consider the text-processing language to ensure correct processing of natural language content.</p>
 
@@ -977,7 +977,7 @@ containing a type identifier.
 
         <p>All objects returned by reconciliation services (entities, types, properties, candidates, features, etc.) MAY declare an explicit text <a href="https://www.w3.org/International/articles/inline-bidi-markup/uba-basics">
         base direction</a> in a <code>dir</code> field. The <code>dir</code> value MUST be <code>ltr</code> for left-to-right, <code>rtl</code> for right-to-left, or <code>auto</code> for determining the direction by examining the content of each JSON field.
-        This base direction applies to the natural language fields of the object: <code>name</code> and <code>description</code> (for candidates etc.), <code>v</code> and <code>str</code> (for <a>property values</a>).
+        This base direction applies to the natural language fields of the object: <code>name</code> and <code>description</code> (for candidates etc.), <code>v</code> and <code>str</code> (for <a>property values</a>), <code>helpText</code> (for <a>data extension property settings</a>).
         Nested objects inherit the base direction of their parent, and can override it by setting their own <code>dir</code> value. A default base direction for any natural language string returned or processed by a service MAY be set in the <code>dir</code> field of the
         <a href="#service-manifest">service manifest</a>. If no explicit base direction is given, left-to-right is considered the default base direction. Clients SHOULD consider the base direction to ensure correct rendering of content, e.g. by setting corresponding <code>dir</code> attributes when rendering JSON responses in HTML.
         For instance, rendering a Persian label for 'Yahoo!' like <code>یاهو!</code> right-to-left will correctly display as <code dir="rtl">یاهو!</code>.</p>

--- a/1.0-draft/schemas/data-extension-property-proposal.json
+++ b/1.0-draft/schemas/data-extension-property-proposal.json
@@ -20,6 +20,12 @@
           "description": {
             "type": "string",
             "description": "An optional description which can be provided to disambiguate namesakes, providing more context."
+          },
+          "lang": {
+            "$ref": "lang.json"
+          },
+          "dir": {
+            "$ref": "dir.json"
           }
         },
         "required": [

--- a/1.0-draft/schemas/data-extension-response.json
+++ b/1.0-draft/schemas/data-extension-response.json
@@ -15,6 +15,12 @@
           "name": {
             "type": "string"
           },
+          "lang": {
+            "$ref": "lang.json"
+          },
+          "dir": {
+            "$ref": "dir.json"
+          },
           "type": {
             "type": "object",
             "properties": {
@@ -23,6 +29,12 @@
               },
               "name": {
                 "type": "string"
+              },
+              "lang": {
+                "$ref": "lang.json"
+              },
+              "dir": {
+                "$ref": "dir.json"
               }
             },
             "required": [

--- a/1.0-draft/schemas/data-extension-response.json
+++ b/1.0-draft/schemas/data-extension-response.json
@@ -81,10 +81,10 @@
                             "type": "string"
                           },
                           "lang": {
-                            "type": "string"
+                            "$ref": "lang.json"
                           },
                           "dir": {
-                            "type": "string"
+                            "$ref": "dir.json"
                           }
                         },
                         "required": [
@@ -100,10 +100,10 @@
                             "type": "string"
                           },
                           "lang": {
-                            "type": "string"
+                            "$ref": "lang.json"
                           },
                           "dir": {
-                            "type": "string"
+                            "$ref": "dir.json"
                           }
                         },
                         "required": [

--- a/1.0-draft/schemas/dir.json
+++ b/1.0-draft/schemas/dir.json
@@ -1,0 +1,10 @@
+{
+    "$id": "https://reconciliation-api.github.io/specs/draft/schemas/dir.json",
+    "type": "string",
+    "enum": [
+        "ltr",
+        "rtl",
+        "auto"
+    ],
+    "description": "The text direction for the natural language fields of this object"
+}

--- a/1.0-draft/schemas/lang.json
+++ b/1.0-draft/schemas/lang.json
@@ -1,0 +1,5 @@
+{
+    "$id": "https://reconciliation-api.github.io/specs/draft/schemas/lang.json",
+    "type": "string",
+    "description": "The text-processing language for the natural language fields of this object"
+}

--- a/1.0-draft/schemas/manifest.json
+++ b/1.0-draft/schemas/manifest.json
@@ -18,6 +18,12 @@
       "type": "string",
       "description": "A human-readable name for the service or data source"
     },
+    "lang": {
+      "$ref": "lang.json"
+    },
+    "dir": {
+      "$ref": "dir.json"
+    },
     "documentation": {
       "type": "string",
       "description": "A URI which hosts documentation about this service"
@@ -136,6 +142,12 @@
                   },
                   "helpText": {
                     "type": "string"
+                  },
+                  "lang": {
+                    "$ref": "lang.json"
+                  },
+                  "dir": {
+                    "$ref": "dir.json"
                   }
                 },
                 "required": [
@@ -165,6 +177,12 @@
                   },
                   "helpText": {
                     "type": "string"
+                  },
+                  "lang": {
+                    "$ref": "lang.json"
+                  },
+                  "dir": {
+                    "$ref": "dir.json"
                   }
                 },
                 "required": [
@@ -194,6 +212,12 @@
                   },
                   "helpText": {
                     "type": "string"
+                  },
+                  "lang": {
+                    "$ref": "lang.json"
+                  },
+                  "dir": {
+                    "$ref": "dir.json"
                   }
                 },
                 "required": [
@@ -224,6 +248,12 @@
                   "helpText": {
                     "type": "string"
                   },
+                  "lang": {
+                    "$ref": "lang.json"
+                  },
+                  "dir": {
+                    "$ref": "dir.json"
+                  },
                   "choices": {
                     "type": "array",
                     "items": {
@@ -234,6 +264,12 @@
                         },
                         "name": {
                           "type": "string"
+                        },
+                        "lang": {
+                          "$ref": "lang.json"
+                        },
+                        "dir": {
+                          "$ref": "dir.json"
                         }
                       },
                       "required": [

--- a/1.0-draft/schemas/reconciliation-query-batch.json
+++ b/1.0-draft/schemas/reconciliation-query-batch.json
@@ -24,6 +24,12 @@
             },
             "name": {
               "type": "string"
+            },
+            "lang": {
+              "$ref": "lang.json"
+            },
+            "dir": {
+              "$ref": "dir.json"
             }
           },
           "required": [

--- a/1.0-draft/schemas/reconciliation-query-batch.json
+++ b/1.0-draft/schemas/reconciliation-query-batch.json
@@ -52,8 +52,10 @@
             "description": "The maximum number of candidates to return"
           },
           "lang": {
-            "type": "string",
-            "description": "The text-processing language for the query"
+            "$ref": "lang.json"
+          },
+          "dir": {
+            "$ref": "dir.json"
           },
           "conditions": {
             "type": "array",

--- a/1.0-draft/schemas/reconciliation-result-batch.json
+++ b/1.0-draft/schemas/reconciliation-result-batch.json
@@ -30,6 +30,12 @@
                   "type": "string",
                   "description": "Optional description of the candidate entity"
                 },
+                "lang": {
+                  "$ref": "lang.json"
+                },
+                "dir": {
+                  "$ref": "dir.json"
+                },
                 "score": {
                   "type": "number",
                   "description": "Number indicating how likely it is that the candidate matches the query"
@@ -47,6 +53,12 @@
                       "name": {
                         "type": "string",
                         "description": "A human-readable name for the feature"
+                      },
+                      "lang": {
+                        "$ref": "lang.json"
+                      },
+                      "dir": {
+                        "$ref": "dir.json"
                       },
                       "value": {
                         "description": "The value of the feature for this reconciliation candidate",
@@ -85,6 +97,12 @@
                           },
                           "name": {
                             "type": "string"
+                          },
+                          "lang": {
+                            "$ref": "lang.json"
+                          },
+                          "dir": {
+                            "$ref": "dir.json"
                           }
                         },
                         "required": [

--- a/1.0-draft/schemas/suggest-entities-response.json
+++ b/1.0-draft/schemas/suggest-entities-response.json
@@ -21,6 +21,12 @@
             "type": "string",
             "description": "An optional description which can be provided to disambiguate namesakes, providing more context."
           },
+          "lang": {
+            "$ref": "lang.json"
+          },
+          "dir": {
+            "$ref": "dir.json"
+          },
           "notable": {
             "type": "array",
             "description": "Types the suggest entity belongs to",
@@ -35,6 +41,12 @@
                     },
                     "name": {
                       "type": "string"
+                    },
+                    "lang": {
+                      "$ref": "lang.json"
+                    },
+                    "dir": {
+                      "$ref": "dir.json"
                     }
                   },
                   "required": [

--- a/1.0-draft/schemas/suggest-properties-response.json
+++ b/1.0-draft/schemas/suggest-properties-response.json
@@ -21,6 +21,12 @@
             "type": "string",
             "description": "An optional description which can be provided to disambiguate namesakes, providing more context."
           },
+          "lang": {
+            "$ref": "lang.json"
+          },
+          "dir": {
+            "$ref": "dir.json"
+          },
           "matchQualifiers": {
             "type": "array",
             "description": "An optional array of objects representing the matchQualifiers supported for the suggested property",
@@ -34,6 +40,12 @@
                 "name": {
                   "type": "string",
                   "description": "Name of the matchQualifier"
+                },
+                "lang": {
+                  "$ref": "lang.json"
+                },
+                "dir": {
+                  "$ref": "dir.json"
                 }
               },
               "required": [

--- a/1.0-draft/schemas/type.json
+++ b/1.0-draft/schemas/type.json
@@ -14,6 +14,12 @@
             "type": "string",
             "description": "An optional description which can be provided to disambiguate namesakes, providing more context."
         },
+        "lang": {
+          "$ref": "lang.json"
+        },
+        "dir": {
+          "$ref": "dir.json"
+        },
         "broader": {
             "type": "array",
             "description": "An optional array of types, each representing a direct (i.e., immediate) broader category of entities.",


### PR DESCRIPTION
Add `lang` & `dir` to schemas for all objects with natural language fields, see spec sections [8.2](https://deploy-preview-190--reconciliation-api-specs.netlify.app/1.0-draft/#text-processing-language) and [8.3](https://deploy-preview-190--reconciliation-api-specs.netlify.app/1.0-draft/#text-direction).

This should be the missing part to resolve #138.