### PR TITLE
Updated spec and schema to add "id" matchType

### DIFF
--- a/1.0-draft/index.html
+++ b/1.0-draft/index.html
@@ -549,12 +549,12 @@ database are instances of this type.</dd>
 		by allowing clients to specify an attribute of entities that should match. It consists of:
          <dl>
             <dt><code>matchType</code></dt>
-            <dd>{{String}} (required) either <code>name</code> or <code>property</code>, depending on whether the condition relates to entity names or their properties.</dd>
+            <dd>{{String}} (required) either <code>name</code> or <code>id</code> or <code>property</code>, depending on whether the condition relates to entity names, entity ids or their properties.</dd>
             <dt><code>propertyId</code></dt>
             <dd>{{String}} (required if the <code>matchType</code> is <code>property</code>) a <a href='#properties'>property</a> identifier.</dd>
             <dt><code>propertyValue</code></dt>
             <dd>{{String}} (required) one or more <a>property values</a>. If <code>matchType</code> is <code>name</code>, then this value is to
-                be matched to entity names, otherwise to the property values via the supplied <code>propertyId</code>. The specifics of how this similarity
+                be matched to entity names. If <code>matchType</code> is <code>id</code>, then this value is to be matched to entity ids, otherwise to the property values via the supplied <code>propertyId</code>. The specifics of how this similarity
                 is defined are determined by the service.</dd> 
             <dt><code>required</code></dt>
             <dd>{{Boolean}} (optional) to indicate if a match for the property is required for an entity to enter the list of candidates (i.e. acting like a filter or a WHERE clause in SQL)

--- a/1.0-draft/schemas/reconciliation-query-batch.json
+++ b/1.0-draft/schemas/reconciliation-query-batch.json
@@ -72,9 +72,10 @@
               "properties": {
                 "matchType": {
                   "type": "string",
-                  "description": "A string to indicate whether to match the supplied value to entity names or property values",
+                  "description": "A string to indicate whether to match the supplied value to entity names, entity ids or property values",
                   "enum": [
                     "name",
+                    "id",
                     "property"
                   ]
                 },
@@ -83,7 +84,7 @@
                   "description": "The identifier of the property, whose values will be compared to the values supplied. Required if 'matchType' is 'property'."
                 },
                 "propertyValue": {
-                  "description": "A value (or array of values) to match against the entity names or property values associated with the property on each candidate",
+                  "description": "A value (or array of values) to match against the entity names, entity ids, or property values associated with the property on each candidate",
                   "oneOf": [
                     {
                       "$ref": "#/definitions/property_value"


### PR DESCRIPTION
Updated spec and schema to add "id" as an explicit matchType option for reconciliation queries.